### PR TITLE
feat: Added support for `functools` partial  and partialmethod

### DIFF
--- a/funkagent/parser.py
+++ b/funkagent/parser.py
@@ -33,14 +33,11 @@ def extract_params(doc_str: str):
 
 def func_to_json(func):
     # Check if the function is a functools.partial
-    if isinstance(func, functools.partial):
-        fixed_args = dict(zip(func.func.__code__.co_varnames, func.args))
-        print(fixed_args)
-        _func = func.func
-    elif isinstance(func, functools.partialmethod):
+    if isinstance(func, functools.partial) or isinstance(func, functools.partialmethod):
         fixed_args = func.keywords
-        print(fixed_args)
         _func = func.func
+        if isinstance(func, functools.partial) and (fixed_args is None or fixed_args == {}):
+            fixed_args = dict(zip(func.func.__code__.co_varnames, func.args))
     else:
         fixed_args = {}
         _func = func

--- a/funkagent/parser.py
+++ b/funkagent/parser.py
@@ -1,3 +1,4 @@
+import functools
 import inspect
 import re
 
@@ -12,41 +13,64 @@ def type_mapping(dtype):
     else:
         return "string"
 
+
 def extract_params(doc_str: str):
-    # parse the docstring to get the descriptions for each parameter in dict format
-    params_str = doc_str.split("\n\n")[1].split("\n")
+    # split doc string by newline, skipping empty lines
+    params_str = [line for line in doc_str.split("\n") if line.strip()]
     params = {}
     for line in params_str:
-        param_match = re.findall(r'(?<=:param )\w+(?=:)', line)
-        if param_match != []:
-            param_name = param_match[0]
-            desc_match = line.replace(f":param {param_name}:", "").strip()
-            params[param_name] = desc_match
+        # we only look at lines starting with ':param'
+        if line.strip().startswith(':param'):
+            param_match = re.findall(r'(?<=:param )\w+', line)
+            if param_match:
+                param_name = param_match[0]
+                desc_match = line.replace(f":param {param_name}:", "").strip()
+                # if there is a description, store it
+                if desc_match:
+                    params[param_name] = desc_match
     return params
 
+
 def func_to_json(func):
+    # Check if the function is a functools.partial
+    if isinstance(func, functools.partial):
+        fixed_args = dict(zip(func.func.__code__.co_varnames, func.args))
+        print(fixed_args)
+        _func = func.func
+    elif isinstance(func, functools.partialmethod):
+        fixed_args = func.keywords
+        print(fixed_args)
+        _func = func.func
+    else:
+        fixed_args = {}
+        _func = func
+
     # first we get function name
-    func_name = func.__name__
+    func_name = _func.__name__
     # then we get the function annotations
-    argspec = inspect.getfullargspec(func)
+    argspec = inspect.getfullargspec(_func)
     # get the function docstring
-    func_doc = inspect.getdoc(func)
+    func_doc = inspect.getdoc(_func)
     # parse the docstring to get the description
-    func_description = func_doc.split("\n\n")[0]
-    # get params
-    params = argspec.annotations
-    if 'return' in params.keys():
-        del params['return']
+    func_description = ''.join([line for line in func_doc.split("\n") if not line.strip().startswith(':')])
     # parse the docstring to get the descriptions for each parameter in dict format
-    param_details = extract_params(func_doc)
-    # attach parameter types to params
+    param_details = extract_params(func_doc) if func_doc else {}
+    # attach parameter types to params and exclude fixed args
+    # get params
+    params = {}
     for param_name in argspec.args:
-        params[param_name] = {
-            "description": param_details.get(param_name) or "",
-            "type": type_mapping(argspec.annotations[param_name])
-        }
-    # get parameters for function including default values (that are optional)
-    len_optional_params = len(inspect.getfullargspec(func).defaults)
+        if param_name not in fixed_args.keys():
+            params[param_name] = {
+                "description": param_details.get(param_name) or "",
+                "type": type_mapping(argspec.annotations.get(param_name, type(None)))
+            }
+    # calculate required parameters excluding fixed args
+    # _required = [arg for arg in argspec.args if arg not in fixed_args]
+    _required = [i for i in argspec.args if i not in fixed_args.keys()]
+    if inspect.getfullargspec(_func).defaults:
+        _required = [argspec.args[i] for i, a in enumerate(argspec.args) if
+                     argspec.args[i] not in inspect.getfullargspec(_func).defaults and argspec.args[
+                         i] not in fixed_args.keys()]
     # then return everything in dict
     return {
         "name": func_name,
@@ -55,5 +79,5 @@ def func_to_json(func):
             "type": "object",
             "properties": params
         },
-        "required": argspec.args[:len_optional_params]
+        "required": _required
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ readme = "README.md"
 python = "^3.9"
 openai = "^0.27.8"
 
+[tool.poetry.group.test.dependencies]
+pytest = "^7.4.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,0 +1,246 @@
+import functools
+import json
+
+from funkagent.parser import func_to_json
+
+
+def func_with_no_params():
+    """
+    This function has no parameters
+    :return:
+    """
+    return 1
+
+
+def func_with_mandatory_params_single_space_doc(a: str, b: str):
+    """
+    This function has mandatory parameters
+    :param a:
+    :param b:
+    :return:
+    """
+    return 1
+
+
+def func_with_optional_params_single_space_doc(a: str, b: str = "b"):
+    """
+    This function has optional parameters
+    :param a:
+    :param b:
+    :return:
+    """
+    return 1
+
+
+def func_with_mandatory_params_double_space_doc(a: str, b: str):
+    """
+    This function has mandatory parameters
+
+    :param a:
+    :param b:
+    :return:
+    """
+    return 1
+
+
+def func_with_optional_params_double_space_doc(a: str, b: str = "b"):
+    """
+    This function has optional parameters
+
+    :param a:
+    :param b:
+    :return:
+    """
+    return 1
+
+
+def test_func_to_json_func_with_no_params():
+    """
+    This function tests func_to_json with a function that has no parameters
+    :return:
+    """
+    _json_fun = func_to_json(func_with_no_params)
+    assert _json_fun["name"] == "func_with_no_params"
+    assert _json_fun["description"] == "This function has no parameters"
+    assert 'properties' in _json_fun["parameters"]
+    assert 'type' in _json_fun["parameters"]
+    assert _json_fun["parameters"]["type"] == "object"
+    assert _json_fun["parameters"]["properties"] == {}
+    assert _json_fun["required"] == []
+
+
+def test_func_to_json_func_with_mandatory_params_single_space_doc():
+    """
+    This function tests func_to_json with a function that has mandatory parameters and single space doc
+    :return:
+    """
+    _json_fun = func_to_json(func_with_mandatory_params_single_space_doc)
+    assert _json_fun["name"] == "func_with_mandatory_params_single_space_doc"
+    assert _json_fun["description"] == "This function has mandatory parameters"
+    assert 'properties' in _json_fun["parameters"]
+    assert 'type' in _json_fun["parameters"]
+    assert _json_fun["parameters"]["type"] == "object"
+    assert _json_fun["parameters"]["properties"] == {
+        "a": {
+            "description": "",
+            "type": "string"
+        },
+        "b": {
+            "description": "",
+            "type": "string"
+        }
+    }
+    assert _json_fun["required"] == ["a", "b"]
+
+
+def test_func_to_json_partial_func_with_mandatory_params_single_space_doc():
+    """
+    This function tests func_to_json with a function that has mandatory parameters and single space doc
+    :return:
+    """
+    _json_fun = func_to_json(functools.partial(func_with_mandatory_params_single_space_doc, "a"))
+    assert _json_fun["name"] == "func_with_mandatory_params_single_space_doc"
+    assert _json_fun["description"] == "This function has mandatory parameters"
+    assert 'properties' in _json_fun["parameters"]
+    assert 'type' in _json_fun["parameters"]
+    assert _json_fun["parameters"]["type"] == "object"
+    assert _json_fun["parameters"]["properties"] == {
+        "b": {
+            "description": "",
+            "type": "string"
+        }
+    }
+    assert _json_fun["required"] == ["b"]
+
+
+def test_func_to_json_partialmethod_func_with_mandatory_params_single_space_doc():
+    """
+    This function tests func_to_json with a function that has mandatory parameters and single space doc
+    :return:
+    """
+    _json_fun = func_to_json(functools.partialmethod(func_with_mandatory_params_single_space_doc, b="b"))
+    assert _json_fun["name"] == "func_with_mandatory_params_single_space_doc"
+    assert _json_fun["description"] == "This function has mandatory parameters"
+    assert 'properties' in _json_fun["parameters"]
+    assert 'type' in _json_fun["parameters"]
+    assert _json_fun["parameters"]["type"] == "object"
+    assert _json_fun["parameters"]["properties"] == {
+        "a": {
+            "description": "",
+            "type": "string"
+        }
+    }
+    assert _json_fun["required"] == ["a"]
+
+
+def test_func_to_json_func_with_optional_params_single_space_doc():
+    """
+    This function tests func_to_json with a function that has optional parameters and single space doc
+    :return:
+    """
+    _json_fun = func_to_json(func_with_optional_params_single_space_doc)
+    assert _json_fun["name"] == "func_with_optional_params_single_space_doc"
+    assert _json_fun["description"] == "This function has optional parameters"
+    assert 'properties' in _json_fun["parameters"]
+    assert 'type' in _json_fun["parameters"]
+    assert _json_fun["parameters"]["type"] == "object"
+    assert _json_fun["parameters"]["properties"] == {
+        "a": {
+            "description": "",
+            "type": "string"
+        },
+        "b": {
+            "description": "",
+            "type": "string"
+        }
+    }
+    assert _json_fun["required"] == ["a"]
+
+
+def test_func_to_json_partial_func_with_optional_params_single_space_doc():
+    """
+    This function tests func_to_json with a function that has optional parameters and single space doc
+    :return:
+    """
+    _json_fun = func_to_json(functools.partial(func_with_optional_params_single_space_doc, "a"))
+    print(_json_fun)
+    assert _json_fun["name"] == "func_with_optional_params_single_space_doc"
+    assert _json_fun["description"] == "This function has optional parameters"
+    assert 'properties' in _json_fun["parameters"]
+    assert 'type' in _json_fun["parameters"]
+    assert _json_fun["parameters"]["type"] == "object"
+    assert _json_fun["parameters"]["properties"] == {
+        "b": {
+            "description": "",
+            "type": "string"
+        }
+    }
+    assert _json_fun["required"] == []
+
+
+def test_func_to_json_partialmethod_func_with_optional_params_single_space_doc():
+    """
+    This function tests func_to_json with a function that has optional parameters and single space doc
+    :return:
+    """
+    _json_fun = func_to_json(functools.partialmethod(func_with_optional_params_single_space_doc, b="b"))
+    assert _json_fun["name"] == "func_with_optional_params_single_space_doc"
+    assert _json_fun["description"] == "This function has optional parameters"
+    assert 'properties' in _json_fun["parameters"]
+    assert 'type' in _json_fun["parameters"]
+    assert _json_fun["parameters"]["type"] == "object"
+    assert _json_fun["parameters"]["properties"] == {
+        "a": {
+            "description": "",
+            "type": "string"
+        }
+    }
+    assert _json_fun["required"] == ['a']
+
+
+def test_func_to_json_func_with_mandatory_params_double_space_doc():
+    """
+    This function tests func_to_json with a function that has mandatory parameters and double space doc
+    :return:
+    """
+    _json_fun = func_to_json(func_with_mandatory_params_double_space_doc)
+    assert _json_fun["name"] == "func_with_mandatory_params_double_space_doc"
+    assert _json_fun["description"] == "This function has mandatory parameters"
+    assert 'properties' in _json_fun["parameters"]
+    assert 'type' in _json_fun["parameters"]
+    assert _json_fun["parameters"]["type"] == "object"
+    assert _json_fun["parameters"]["properties"] == {
+        "a": {
+            "description": "",
+            "type": "string"
+        },
+        "b": {
+            "description": "",
+            "type": "string"
+        }
+    }
+    assert _json_fun["required"] == ["a", "b"]
+
+
+def test_func_to_json_func_with_optional_params_double_space_doc():
+    """
+    This function tests func_to_json with a function that has optional parameters and double space doc
+    :return:
+    """
+    _json_fun = func_to_json(func_with_optional_params_double_space_doc)
+    assert _json_fun["name"] == "func_with_optional_params_double_space_doc"
+    assert _json_fun["description"] == "This function has optional parameters"
+    assert 'properties' in _json_fun["parameters"]
+    assert 'type' in _json_fun["parameters"]
+    assert _json_fun["parameters"]["type"] == "object"
+    assert _json_fun["parameters"]["properties"] == {
+        "a": {
+            "description": "",
+            "type": "string"
+        },
+        "b": {
+            "description": "",
+            "type": "string"
+        }
+    }
+    assert _json_fun["required"] == ["a"]

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -98,7 +98,7 @@ def test_func_to_json_partial_func_with_mandatory_params_single_space_doc():
     This function tests func_to_json with a function that has mandatory parameters and single space doc
     :return:
     """
-    _json_fun = func_to_json(functools.partial(func_with_mandatory_params_single_space_doc, "a"))
+    _json_fun = func_to_json(functools.partial(func_with_mandatory_params_single_space_doc, a="a"))
     assert _json_fun["name"] == "func_with_mandatory_params_single_space_doc"
     assert _json_fun["description"] == "This function has mandatory parameters"
     assert 'properties' in _json_fun["parameters"]
@@ -158,6 +158,27 @@ def test_func_to_json_func_with_optional_params_single_space_doc():
 
 
 def test_func_to_json_partial_func_with_optional_params_single_space_doc():
+    """
+    This function tests func_to_json with a function that has optional parameters and single space doc
+    :return:
+    """
+    _json_fun = func_to_json(functools.partial(func_with_optional_params_single_space_doc, a="a"))
+    print(_json_fun)
+    assert _json_fun["name"] == "func_with_optional_params_single_space_doc"
+    assert _json_fun["description"] == "This function has optional parameters"
+    assert 'properties' in _json_fun["parameters"]
+    assert 'type' in _json_fun["parameters"]
+    assert _json_fun["parameters"]["type"] == "object"
+    assert _json_fun["parameters"]["properties"] == {
+        "b": {
+            "description": "",
+            "type": "string"
+        }
+    }
+    assert _json_fun["required"] == []
+
+
+def test_func_to_json_partial_func_with_optional_params_single_space_doc_positional():
     """
     This function tests func_to_json with a function that has optional parameters and single space doc
     :return:


### PR DESCRIPTION
Fixed an issue where there is no empty line separating the description from params in the docstring.
Added support for partial positional args and kwargs